### PR TITLE
Added createClient and ClientProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+/coverage

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --env=jsdom",
+    "test": "react-scripts test --env=jsdom --coverage",
     "eject": "react-scripts eject"
   },
   "browserslist": [

--- a/src/ClientProvider.jsx
+++ b/src/ClientProvider.jsx
@@ -1,2 +1,6 @@
-// TODO this is where we can setup a client object with the domain, headers, and other
-// options, then be able to retrieve the client in the useClient hook later on.
+import React from 'react';
+import { createClient } from './client';
+
+export const ClientContext = React.createContext(createClient());
+
+export default ClientContext.Provider;

--- a/src/client/__mocks__/getRequest.js
+++ b/src/client/__mocks__/getRequest.js
@@ -1,0 +1,77 @@
+const response = {
+  xhr: {
+    getResponseHeader: jest.fn(),
+  },
+  response: [],
+};
+
+function buildResponsePromise(responseObject) {
+  const resolveObject = {
+    ...response,
+    ...responseObject,
+  };
+
+  return Promise.resolve(resolveObject);
+}
+
+export default path => ({
+  toPromise: () => {
+    switch (path) {
+      /**
+       * General responses
+       */
+      case 'foo': {
+        return buildResponsePromise({
+          response: { bar: 'baz' },
+        });
+      }
+      /**
+       * Errors
+       */
+      case 'https://example.com/api/v2/404':
+      case '/404': {
+        return Promise.reject(() => {});
+      }
+      /**
+       * Header Link responses
+       */
+      case '/link/next': {
+        return buildResponsePromise({
+          xhr: {
+            getResponseHeader: () =>
+              '<https://example.com/foo?page=7>; rel="next"',
+          },
+        });
+      }
+      case '/link/prev': {
+        return buildResponsePromise({
+          xhr: {
+            getResponseHeader: () =>
+              '<https://example.com/foo?page=5>; rel="prev"',
+          },
+        });
+      }
+      case '/link/first': {
+        return buildResponsePromise({
+          xhr: {
+            getResponseHeader: () =>
+              '<https://example.com/foo?page=1>; rel="first"',
+          },
+        });
+      }
+      case '/link/last': {
+        return buildResponsePromise({
+          xhr: {
+            getResponseHeader: () =>
+              '<https://example.com/foo?page=10>; rel="last"',
+          },
+        });
+      }
+      default: {
+        return buildResponsePromise({
+          response: { url: path },
+        });
+      }
+    }
+  },
+});

--- a/src/client/client.spec.js
+++ b/src/client/client.spec.js
@@ -1,0 +1,50 @@
+import client from './client';
+import getRequest from './getRequest';
+
+// SEE __mocks__/getRequest for which endpoint paths result in what types of
+// responses from the getRequest().toPromise() method.
+jest.mock('./getRequest');
+
+describe('raw client', () => {
+  it('calls getRequest and returns data', async () => {
+    const response = await client.get('foo');
+
+    expect(response.data).toEqual({ bar: 'baz' });
+    expect(response.links).toEqual({
+      next: null,
+      prev: null,
+      first: null,
+      last: null,
+    });
+  });
+
+  it('rejects when when an error occurs', async () => {
+    expect(client.get('/404')).rejects.toThrow();
+  });
+
+  describe('links', () => {
+    it('returns next link', async () => {
+      const response = await client.get('/link/next');
+
+      expect(response.links.next).toEqual('https://example.com/foo?page=7');
+    });
+
+    it('returns previous link', async () => {
+      const response = await client.get('/link/prev');
+
+      expect(response.links.prev).toEqual('https://example.com/foo?page=5');
+    });
+
+    it('returns first link', async () => {
+      const response = await client.get('/link/first');
+
+      expect(response.links.first).toEqual('https://example.com/foo?page=1');
+    });
+
+    it('returns last link', async () => {
+      const response = await client.get('/link/last');
+
+      expect(response.links.last).toEqual('https://example.com/foo?page=10');
+    });
+  });
+});

--- a/src/client/createClient.js
+++ b/src/client/createClient.js
@@ -1,5 +1,4 @@
 import client from './client';
-import { buildFailureTestResult } from '@jest/test-result';
 
 /**
  * This is a wrapper around client that allows for a base URL to be set once and then use realtive

--- a/src/client/createClient.js
+++ b/src/client/createClient.js
@@ -1,0 +1,78 @@
+import client from './client';
+import { buildFailureTestResult } from '@jest/test-result';
+
+/**
+ * This is a wrapper around client that allows for a base URL to be set once and then use realtive
+ * endpoints from then on.
+ */
+class WrappedClient {
+  /**
+   *
+   * @param {string} baseUrl (optional) Sets the baseUrl for all requests so you can call client
+   * methods using only the relative path to this base url. If no baseUrl is set, it will be set
+   * to `window.location.origin` If this base URL is not a full url, then it will be used as a
+   * prefix appended to `window.location.origin.
+   * Eg: new WrappedClient('/api') => https://localhost/api
+   */
+  constructor(baseUrl) {
+    this.baseUrl = this.buildBaseUrl(baseUrl);
+  }
+
+  /**
+   * Builds the base url. If a full domain name is passed, then returns that domain. If no value is
+   * passed, will grab the value from `window.location.origin`. If relative path is passed, builds
+   * the url from `window.location.origin` the provided relative path.
+   * @param {string} baseUrl
+   * @returns {string} Full base URL
+   */
+  buildBaseUrl(baseUrl) {
+    if (typeof baseUrl === 'undefined') {
+      return window.location.origin;
+    }
+
+    if (!baseUrl.startsWith('http')) {
+      return `${window.location.origin}${
+        baseUrl.startsWith('/') ? '' : '/'
+      }${baseUrl}`;
+    }
+    return baseUrl;
+  }
+
+  /**
+   * @returns {string} The current base URL for all client requests.
+   */
+  getBaseUrl = () => {
+    return this.baseUrl;
+  };
+
+  /**
+   * Builds a url by taking the provided endpoint and prepending with the base Url if needed.
+   * If the passed endpoint is a full URL, then it will be return unmodified.
+   *
+   * @param {string} endpoint The endpoint to build a URL from.
+   * @returns {string} Full URL for the request.
+   */
+  buildUrl = endpoint => {
+    if (endpoint.startsWith('http')) {
+      return endpoint;
+    }
+
+    return `${this.baseUrl}${endpoint.startsWith('/') ? '' : '/'}${endpoint}`;
+  };
+
+  /**
+   * Wrapps client.get by inspecting the endpoint, if it begins with http then it will  just pass
+   * the entire url directly to client with no modification, otherwise it will prepend the base
+   * url to the endpoint then call client.get().
+   *
+   * @see src/client/client.js:get for usage of this function.
+   */
+  get = (endpoint, ...params) => {
+    const url = this.buildUrl(endpoint);
+    return client.get(url, ...params);
+  };
+}
+
+export default function createClient(baseUrl) {
+  return new WrappedClient(baseUrl);
+}

--- a/src/client/createClient.spec.js
+++ b/src/client/createClient.spec.js
@@ -1,0 +1,56 @@
+import createClient from './createClient';
+import getRequest from './getRequest';
+
+// SEE __mocks__/getRequest for which endpoint paths result in what types of
+// responses from the getRequest().toPromise() method.
+jest.mock('./getRequest');
+
+describe('createClient', () => {
+  it('intializes', () => {
+    const client = createClient('https://example.com/foo');
+    expect(client.getBaseUrl()).toBe('https://example.com/foo');
+  });
+
+  it('intializes with browser url when no baseUrl is passed', () => {
+    const client = createClient();
+    expect(client.getBaseUrl()).toBe('http://localhost');
+  });
+
+  it('intializes with browser url and prefix', () => {
+    const client = createClient('/api/v2');
+    expect(client.getBaseUrl()).toBe('http://localhost/api/v2');
+  });
+
+  it('intializes with browser url and prefix with no leading /', () => {
+    const client = createClient('api/v2');
+    expect(client.getBaseUrl()).toBe('http://localhost/api/v2');
+  });
+
+  describe('get()', () => {
+    it('createdClient getRequest creates full url from relative endpoint', async () => {
+      const client = createClient('https://example.com/api/v2');
+      const response = await client.get('foo');
+
+      expect(response.data).toEqual({ url: 'https://example.com/api/v2/foo' });
+    });
+
+    it('does not double leading /', async () => {
+      const client = createClient('https://example.com/api/v2');
+      const response = await client.get('/foo');
+
+      expect(response.data).toEqual({ url: 'https://example.com/api/v2/foo' });
+    });
+
+    it('does not modify full urls', async () => {
+      const client = createClient('https://example.com/api/v2');
+      const response = await client.get('https://github.com/users');
+
+      expect(response.data).toEqual({ url: 'https://github.com/users' });
+    });
+
+    it('rejects when when an error occurs', async () => {
+      const client = createClient('https://example.com/api/v2');
+      expect(client.get('/404')).rejects.toThrow();
+    });
+  });
+});

--- a/src/client/getRequest.js
+++ b/src/client/getRequest.js
@@ -1,0 +1,21 @@
+import { ajax } from 'rxjs/ajax';
+import { catchError, map } from 'rxjs/operators';
+import { throwError, of } from 'rxjs';
+
+const getRequest = path =>
+  ajax(path).pipe(
+    map(response => {
+      if (response === null) {
+        return throwError('API Timed out', response);
+      }
+      console.log('api response: ', response);
+      return response;
+    }),
+    catchError(error => {
+      console.log(error);
+      console.error('api error: ', error.response);
+      return of(error);
+    }),
+  );
+
+export default getRequest;

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,0 +1,1 @@
+export { default } from './client';

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -1,1 +1,2 @@
 export { default } from './client';
+export { default as createClient } from './createClient';

--- a/src/components/ReposCard/ReposCard.jsx
+++ b/src/components/ReposCard/ReposCard.jsx
@@ -15,7 +15,7 @@ export default function ReposCard() {
   return (
     <Card>
       <CardHeader title="Repositories" />
-      <Request endpoint="https://api.github.com/orgs/storybookjs/repos?per_page=5">
+      <Request endpoint="/orgs/storybookjs/repos?per_page=5">
         {({ loading, error, data, links }) => (
           <React.Fragment>
             <ReposList repos={data} isLoading={loading} error={error} />

--- a/src/components/UsersCard/UsersCard.jsx
+++ b/src/components/UsersCard/UsersCard.jsx
@@ -15,7 +15,7 @@ export default function UsersCard() {
   return (
     <Card>
       <CardHeader title="Users" />
-      <Request endpoint="https://api.github.com/users?per_page=5">
+      <Request endpoint="/users?per_page=5">
         {({ loading, error, data, links }) => (
           <React.Fragment>
             <UsersList users={data} isLoading={loading} error={error} />

--- a/src/index.js
+++ b/src/index.js
@@ -1,18 +1,24 @@
-import React from "react";
-import ReactDOM from "react-dom";
-import "./styles.css";
+import React from 'react';
+import ReactDOM from 'react-dom';
+import './styles.css';
 
-import Typography from "@material-ui/core/Typography";
-import Dashboard from "./components/Dashboard";
+import Typography from '@material-ui/core/Typography';
+import Dashboard from './components/Dashboard';
+
+import { createClient } from './client';
+import ClientProvider from './ClientProvider';
 
 function App() {
+  const client = createClient('https://api.github.com');
   return (
     <div className="App">
       <Typography variant="h2">Testing RxJS API Calls</Typography>
-      <Dashboard />
+      <ClientProvider value={client}>
+        <Dashboard />
+      </ClientProvider>
     </div>
   );
 }
 
-const rootElement = document.getElementById("root");
+const rootElement = document.getElementById('root');
 ReactDOM.render(<App />, rootElement);

--- a/src/useEndpointData.js
+++ b/src/useEndpointData.js
@@ -13,11 +13,10 @@
  *  - [ ] It should also allow for editing headers
  *  - [ ] Allow for passing paramas as an object.
  *  - [ ] Can we do a put/post/delete with this?
- *  - [ ] Should return the client object  maybe? Get it from useContext
  * ```
  */
 import React from 'react';
-import client from './client';
+import { createClient } from './client';
 
 const defaultOptions = {
   // TODO: deprecate: this doesn't really make sense, just make it null
@@ -38,6 +37,9 @@ export default function useEndpointData(path, options) {
   const [previousLink, setPreviousLink] = React.useState();
   const [firstLink, setFirstLink] = React.useState();
   const [lastLink, setLastLink] = React.useState();
+
+  // Get client from context or create the client.
+  const client = createClient();
 
   let getNext = null;
   if (nextLink) {
@@ -86,7 +88,7 @@ export default function useEndpointData(path, options) {
       }
     };
     load();
-  }, [path, currentEndpoint]);
+  }, [path, currentEndpoint, client]);
   return [
     value,
     isLoading,

--- a/src/useEndpointData.js
+++ b/src/useEndpointData.js
@@ -16,7 +16,8 @@
  * ```
  */
 import React from 'react';
-import { createClient } from './client';
+
+import { ClientContext } from './ClientProvider';
 
 const defaultOptions = {
   // TODO: deprecate: this doesn't really make sense, just make it null
@@ -39,7 +40,7 @@ export default function useEndpointData(path, options) {
   const [lastLink, setLastLink] = React.useState();
 
   // Get client from context or create the client.
-  const client = createClient();
+  let client = React.useContext(ClientContext);
 
   let getNext = null;
   if (nextLink) {


### PR DESCRIPTION
* [NEW] New `ClientProvider` for accessing client via Context. 
* [NEW] New `createClient` helper function to create a new client. This also provides a wrapped client for setting base URL once then using relative paths for all other client requests. 
* [NEW] Added tests for client and createClient. 